### PR TITLE
RPLidar does not restart when plugged back in

### DIFF
--- a/src/node.cpp
+++ b/src/node.cpp
@@ -226,7 +226,11 @@ int main(int argc, char * argv[]) {
         ROS_ERROR("Create Driver fail, exit");
         return -2;
     }
-
+    
+    ros::ServiceServer stop_motor_service = nh.advertiseService("stop_motor", stop_motor);
+    ros::ServiceServer start_motor_service = nh.advertiseService("start_motor", start_motor);
+    
+connect:
     if(channel_type == "tcp"){
         // make connection...
         if (IS_FAIL(drv->connect(tcp_ip.c_str(), (_u32)tcp_port))) {
@@ -256,9 +260,6 @@ int main(int argc, char * argv[]) {
         RPlidarDriver::DisposeDriver(drv);
         return -1;
     }
-
-    ros::ServiceServer stop_motor_service = nh.advertiseService("stop_motor", stop_motor);
-    ros::ServiceServer start_motor_service = nh.advertiseService("start_motor", start_motor);
 
     drv->startMotor();
 
@@ -377,6 +378,13 @@ int main(int argc, char * argv[]) {
                              angle_min, angle_max, max_distance,
                              frame_id);
             }
+        } else {
+            rplidar_response_device_health_t healthinfo;
+            op_result = drv->getHealth(healthinfo);
+            if (!IS_OK(op_result)) { 
+                goto connect;
+            } 
+            ros::Duration(0.1).sleep();
         }
 
         ros::spinOnce();

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -385,7 +385,6 @@ connect:
                 ros::Duration(1).sleep();
                 goto connect;
             } 
-            ROS_WARN_THROTTLE(1, "Grab scan data failed.");
         }
 
         ros::spinOnce();

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -236,6 +236,7 @@ connect:
         if (IS_FAIL(drv->connect(tcp_ip.c_str(), (_u32)tcp_port))) {
             ROS_ERROR("Error, cannot bind to the specified serial port %s.",serial_port.c_str());
             RPlidarDriver::DisposeDriver(drv);
+            ros::Duration(1).sleep();
             goto connect;
         }
     }
@@ -244,6 +245,7 @@ connect:
         if (IS_FAIL(drv->connect(serial_port.c_str(), (_u32)serial_baudrate))) {
             ROS_ERROR("Error, cannot bind to the specified serial port %s.",serial_port.c_str());
             RPlidarDriver::DisposeDriver(drv);
+            ros::Duration(1).sleep();
             goto connect;
         }
     }
@@ -380,10 +382,10 @@ connect:
             if (!checkRPLIDARHealth(drv)) {
                 ROS_WARN_THROTTLE(1, "RPLIDAR disconnected. Attempting reconnection.");
                 RPlidarDriver::DisposeDriver(drv);
+                ros::Duration(1).sleep();
                 goto connect;
             } 
             ROS_WARN_THROTTLE(1, "Grab scan data failed.");
-            ros::Duration(0.1).sleep();
         }
 
         ros::spinOnce();


### PR DESCRIPTION
https://www.wrike.com/workspace.htm?acc=1794223#path=folder&id=453101994&p=445543367&a=1794223&c=board&ot=422265705&so=10&bso=10&sd=0&f=assigned%3DqQKHUa7n7aqQ&st=space-364052400&sfi=1

If operation fails, call request health. If request fails except loop and attempt to reconnect again. Request health is used to check issue is a disconnect, not a call to stop_motor.